### PR TITLE
fix #122

### DIFF
--- a/docs/basics/Reducers.md
+++ b/docs/basics/Reducers.md
@@ -142,7 +142,7 @@ function todoApp(state = initialState, action) {
 
 如上，不直接修改 `state` 中的字段，而是返回新对象。新的 `todos` 对象就相当于旧的 `todos` 在末尾加上新建的 todo。而这个新的 todo 又是基于 action 中的数据创建的。
 
-最后，`COMPLETE_TODO` 的实现也很好理解：
+最后，`TOGGLE_TODO` 的实现也很好理解：
 
 ```js
 case TOGGLE_TODO:
@@ -370,7 +370,7 @@ function reducer(state = {}, action) {
 
 ```js
 import { combineReducers } from 'redux'
-import { ADD_TODO, COMPLETE_TODO, SET_VISIBILITY_FILTER, VisibilityFilters } from './actions'
+import { ADD_TODO, TOGGLE_TODO, SET_VISIBILITY_FILTER, VisibilityFilters } from './actions'
 const { SHOW_ALL } = VisibilityFilters
 
 function visibilityFilter(state = SHOW_ALL, action) {
@@ -392,11 +392,11 @@ function todos(state = [], action) {
           completed: false
         }
       ]
-    case COMPLETE_TODO:
+    case TOGGLE_TODO:
       return state.map((todo, index) => {
         if (index === action.index) {
           return Object.assign({}, todo, {
-            completed: true
+            completed: !todo.completed
           })
         }
         return todo


### PR DESCRIPTION
找到未同步的原因了！翻译文本时对照的是[redux.js.org](http://redux.js.org/)，而后来对code部分进行检查时对照的却是[github](https://github.com/reactjs/redux/blob/master/docs/basics/Reducers.md)。不巧，这个期间刚好有一个commit “[(May 3)Change doc examples to use TOGGLE_TODO action consistently (#1690)](https://github.com/reactjs/redux/commit/42c6ed77662fff277ad713603d003a379d491493)” 被合并到redux repo，导致对照用的原文是不一样的。

以后会注意这个情况！