### PR TITLE
关于某句话产生的歧义

### DIFF
--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -8,7 +8,7 @@
 
 当调用异步 API 时，有两个非常关键的时刻：发起请求的时刻，和接收到响应的时刻 （也可能是超时）。
 
-这两个时刻都可能会更改应用的 state；为此，你需要 dispatch 普通的同步 action。一般情况下，每个 API 请求你都有可能 dispatch 至少三种不同的 action：
+这两个时刻都可能会更改应用的 state；为此，你需要 dispatch 普通的同步 action。一般情况下，每个 API 请求你都有可能 dispatch 至少三种 action：
 
 * **一种通知 reducer 请求开始的 action。**
 

--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -8,7 +8,7 @@
 
 当调用异步 API 时，有两个非常关键的时刻：发起请求的时刻，和接收到响应的时刻 （也可能是超时）。
 
-这两个时刻都可能会更改应用的 state；为此，你需要 dispatch 普通的同步 action。一般情况下，每个 API 请求都至少需要三种 action 去被 dispatch：
+这两个时刻都可能会更改应用的 state；为此，你需要 dispatch 普通的同步 action。一般情况下，每个 API 请求都需要 dispatch 至少三种 action：
 
 * **一种通知 reducer 请求开始的 action。**
 

--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -8,7 +8,7 @@
 
 当调用异步 API 时，有两个非常关键的时刻：发起请求的时刻，和接收到响应的时刻 （也可能是超时）。
 
-这两个时刻都可能会更改应用的 state；为此，你需要 dispatch 普通的同步 action。一般情况下，每个 API 请求你都有可能 dispatch 至少三种 action：
+这两个时刻都可能会更改应用的 state；为此，你需要 dispatch 普通的同步 action。一般情况下，每个 API 请求都至少需要三种 action 去被 dispatch：
 
 * **一种通知 reducer 请求开始的 action。**
 

--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -8,17 +8,17 @@
 
 当调用异步 API 时，有两个非常关键的时刻：发起请求的时刻，和接收到响应的时刻 （也可能是超时）。
 
-这两个时刻都可能会更改应用的 state；为此，你需要 dispatch 普通的同步 action。一般情况下，每个 API 请求都至少需要 dispatch 三种不同的 action：
+这两个时刻都可能会更改应用的 state；为此，你需要 dispatch 普通的同步 action。一般情况下，每个 API 请求你都有可能 dispatch 至少三种不同的 action：
 
-* **一个通知 reducer 请求开始的 action。**
+* **一种通知 reducer 请求开始的 action。**
 
   对于这种 action，reducer 可能会切换一下 state 中的 `isFetching` 标记。以此来告诉 UI 来显示进度条。
 
-* **一个通知 reducer 请求成功结束的 action。**
+* **一种通知 reducer 请求成功结束的 action。**
 
   对于这种 action，reducer 可能会把接收到的新数据合并到 state 中，并重置 `isFetching`。UI 则会隐藏进度条，并显示接收到的数据。
 
-* **一个通知 reducer 请求失败的 action。**
+* **一种通知 reducer 请求失败的 action。**
 
   对于这种 action，reducer 可能会重置 `isFetching`。或者，有些 reducer 会保存这些失败信息，并在 UI 里显示出来。
 

--- a/docs/advanced/AsyncActions.md
+++ b/docs/advanced/AsyncActions.md
@@ -8,7 +8,7 @@
 
 当调用异步 API 时，有两个非常关键的时刻：发起请求的时刻，和接收到响应的时刻 （也可能是超时）。
 
-这两个时刻都可能会更改应用的 state；为此，你需要 dispatch 普通的同步 action。一般情况下，每个 API 请求都至少需要 dispatch 三个不同的 action：
+这两个时刻都可能会更改应用的 state；为此，你需要 dispatch 普通的同步 action。一般情况下，每个 API 请求都至少需要 dispatch 三种不同的 action：
 
 * **一个通知 reducer 请求开始的 action。**
 


### PR DESCRIPTION
>原文：

Usually, for any API request you’ll want to dispatch at least three different kinds of actions
* An action informing the reducers that the request **began**.
* An action informing the reducers that the request **finished successfully**.
* An action informing the reducers that the request **failed**.

>译文：

一般情况下，每个 API 请求都至少需要 dispatch 三个不同的 action
>修改：

一般情况下，每个 API 请求都需要至少三种 action 去被 dispatch
>原因：

原文给出的三种 action 其中 “成功” 和 “失败” 的 两种情况下的 action 不会同时发生，所以翻译成 “dispatch 三个” 有点歧义，实际上只是定义了三种 action ，并没有全部被 dispatch
以上都是个人愚见>_<
 
