### PR TITLE
Update ComputingDerivedData.md

### DIFF
--- a/docs/recipes/ComputingDerivedData.md
+++ b/docs/recipes/ComputingDerivedData.md
@@ -314,7 +314,7 @@ const mapDispatchToProps = (dispatch) => {
 }
 
 const VisibleTodoList = connect(
-  makeMapStateToProps,
+  makeMapStateToProps(),
   mapDispatchToProps
 )(TodoList)
 


### PR DESCRIPTION
makeMapStateToProps method lacks of brakets when it was passed as a parameter to the connect method