### PR TITLE
fix a word in UsageWithReact.md

### DIFF
--- a/docs/basics/UsageWithReact.md
+++ b/docs/basics/UsageWithReact.md
@@ -419,7 +419,7 @@ export default App
 
 所有容器组件都可以访问 Redux store，所以可以手动监听它。一种方式是把它以 props 的形式传入到所有容器组件中。但这太麻烦了，因为必须要用 `store` 把展示组件包裹一层，仅仅是因为恰好在组件树中渲染了一个容器组件。
 
-建议的方式是使用指定的 React Redux 组件 [`<Provider>`](https://github.com/reactjs/react-redux/blob/master/docs/api.md#provider-store) 来 [魔法般的](https://doc.react-china.org/docs/context.html) 让所有容器组件都可以访问 store，而不必显示地传递它。只需要在渲染根组件时使用即可。
+建议的方式是使用指定的 React Redux 组件 [`<Provider>`](https://github.com/reactjs/react-redux/blob/master/docs/api.md#provider-store) 来 [魔法般的](https://doc.react-china.org/docs/context.html) 让所有容器组件都可以访问 store，而不必显式地传递它。只需要在渲染根组件时使用即可。
 
 #### `index.js`
 


### PR DESCRIPTION
「而不必显示地传递它」 这里的 `显示` 应该是 `显式`.

「而不必显示地传递它」Here should be `显式` instead of `显示`.